### PR TITLE
Feature/monitor cron

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'adaptavist-replication'
-version '0.3.9'
+version '0.3.10'
 source 'https://github.com/Adaptavist/puppet-replication.git'
 author 'adaptavist'
 summary 'replication Module' 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ replication::database::server::server_tunnels:
 
 By default make sure /etc/stunnel/stunnel.pem exists and user stunnel4 exists...
 
+It is possible to creaet a cron on the Filesystem master that will touch a file in each replicated folder, the point of this is to provide a file thats mtime is updated in a controlled way, this allows a monitoring system to check this file and depending on the mtime determine if replication is working as expected or not.  An example of this is to use the Nagios check_file_age plugin.
+
+The following variables control the "monitor cron"
+
+`create_monitor_cron` - Flag to determine if the file touch cron should be created for each replicated directory, defaults to **`true`**
+
+`monitor_cron_schedule` - The cron schedule for the touch cron, defaults to **`*/10 * * * *`**
+
+`monitor_cron_user`  - The user that the touch cron should run as , defaults to **`root`**
+
+`monitor_cron_cronfile` - The location of the touch cron job file, deafults to **`'/etc/cron.d/fs_replication_monitor'`**
+
+`monitor_cron_file` - The file to be touched by the touch cron, relative to the replicated directory, defaults to **`replication.lock`**
+
 #### Example usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ replication::database::server::server_tunnels:
 
 By default make sure /etc/stunnel/stunnel.pem exists and user stunnel4 exists...
 
-It is possible to creaet a cron on the Filesystem master that will touch a file in each replicated folder, the point of this is to provide a file thats mtime is updated in a controlled way, this allows a monitoring system to check this file and depending on the mtime determine if replication is working as expected or not.  An example of this is to use the Nagios check_file_age plugin.
+It is possible to create a cron on the Filesystem master that will touch a file in each replicated folder, the point of this is to provide a file thats mtime is updated in a controlled way, this allows a monitoring system to check this file and depending on the mtime determine if replication is working as expected or not. An example of this is to use the Nagios check_file_age plugin.
 
 The following variables control the "monitor cron"
 

--- a/manifests/database/client.pp
+++ b/manifests/database/client.pp
@@ -15,7 +15,7 @@ class replication::database::client (
     $semanage_package = $replication::database::params::semanage_package,
     ) inherits replication::database::params {
 
-    if($present == true){
+    if str2bool($present){
         unless ( $client_tunnels == undef ) {
             include stunnel_config
             create_resources('stunnel_config::tun', $client_tunnels)

--- a/manifests/database/server.pp
+++ b/manifests/database/server.pp
@@ -4,7 +4,7 @@ class replication::database::server (
     $server_tunnels = $replication::database::params::server_tunnels,
     $present        = $replication::database::params::present,
     ) inherits replication::database::params {
-    if ($present == true){
+    if str2bool($present){
         unless ( $server_tunnels == undef ) {
             include stunnel_config
             create_resources('stunnel_config::tun', $server_tunnels)

--- a/manifests/filesystem/client.pp
+++ b/manifests/filesystem/client.pp
@@ -10,7 +10,7 @@ class replication::filesystem::client(
     $create_folders = $replication::filesystem::params::create_folders,
     ) inherits replication::filesystem::params {
     
-    if ($present == true){
+    if str2bool($present){
         if ! defined(Class['rsync_config']) {
             #setup rsync server
             class { 'rsync_config' :

--- a/manifests/filesystem/params.pp
+++ b/manifests/filesystem/params.pp
@@ -25,6 +25,11 @@ class replication::filesystem::params {
     $cron_file = '/etc/cron.daily/lsync_daily_sync'
     $cron_rsync_path = '/usr/bin/rsync'
     $cron_rsync_opts = '-ravH --delete'
+    $create_monitor_cron = true
+    $monitor_cron_schedule = '*/10 * * * *'
+    $monitor_cron_user = 'root'
+    $monitor_cron_cronfile = '/etc/cron.d/fs_replication_monitor'
+    $monitor_cron_file = 'replication.lock'
 
     # client setup
     #setup rsync

--- a/manifests/filesystem/server.pp
+++ b/manifests/filesystem/server.pp
@@ -14,7 +14,7 @@ class replication::filesystem::server(
 
     ) inherits replication::filesystem::params {
     
-    if ($present == true){
+    if str2bool($present){
         if ! defined(Class['lsyncd']) {
             #setup rsync server
             class { 'lsyncd' :
@@ -27,7 +27,7 @@ class replication::filesystem::server(
         }
 
         # if a daily cron is required create it
-        if ($create_daily_cron == true) {
+        if str2bool($create_daily_cron) {
             file {'lsync_daily_sync_script':
                 ensure  => file,
                 content => template('replication/lsync_daily_sync.erb'),

--- a/manifests/filesystem/server.pp
+++ b/manifests/filesystem/server.pp
@@ -11,7 +11,11 @@ class replication::filesystem::server(
     $cron_rsync_path       = $replication::filesystem::params::cron_rsync_path,
     $cron_rsync_opts       = $replication::filesystem::params::cron_rsync_opts,
     $lsync_flush_config    = $replication::filesystem::params::lsync_flush_config,
-
+    $create_monitor_cron   = $replication::filesystem::params::create_monitor_cron,
+    $monitor_cron_schedule = $replication::filesystem::params::monitor_cron_schedule,
+    $monitor_cron_user     = $replication::filesystem::params::monitor_cron_user,
+    $monitor_cron_cronfile = $replication::filesystem::params::monitor_cron_cronfile,
+    $monitor_cron_file     = $replication::filesystem::params::monitor_cron_file,
     ) inherits replication::filesystem::params {
     
     if str2bool($present){
@@ -41,6 +45,18 @@ class replication::filesystem::server(
         unless ( $server_tunnels == undef ) {
             include stunnel_config
             create_resources('stunnel_config::tun', $server_tunnels)
+        }
+
+        # if required create a cron to touch files in the replications folder(s) to aid monitoring
+        if str2bool($create_monitor_cron) {
+            file { $monitor_cron_cronfile:
+                ensure  => file,
+                content => template('replication/filesystem_monitor_cron.erb'),
+                path    => $monitor_cron_cronfile,
+                owner   => 'root',
+                group   => 'root',
+                mode    => '0644'
+            }
         }
     }
 }

--- a/manifests/svn/client.pp
+++ b/manifests/svn/client.pp
@@ -12,7 +12,7 @@ class replication::svn::client(
     $present           = $replication::svn::params::present,
     ) inherits replication::svn::params {
 
-    if ($present == true){
+    if str2bool($present){
         include subversion
 
         unless ( $client_tunnels == undef ) {

--- a/manifests/svn/server.pp
+++ b/manifests/svn/server.pp
@@ -13,7 +13,7 @@ class replication::svn::server (
     $client_tunnels         = undef,
     ) inherits replication::svn::params {
 
-    if($present == true){
+    if str2bool($present){
 
         unless ( $client_tunnels == undef ) {
             include stunnel_config

--- a/templates/filesystem_monitor_cron.erb
+++ b/templates/filesystem_monitor_cron.erb
@@ -1,0 +1,3 @@
+<% @rsync_modules.each_pair do |rsync_name, rsync_module| -%>
+<%= @monitor_cron_schedule %> <%= @monitor_cron_user %> touch <%= rsync_module['source'] %>/<%= @monitor_cron_file %>
+<% end -%>


### PR DESCRIPTION
allows for the creation of a cron to touch files within each replicated folder, this can then be used to monitor if the replication is working on the slave